### PR TITLE
Commit bit pup

### DIFF
--- a/pup-0006.md
+++ b/pup-0006.md
@@ -1,0 +1,101 @@
+---
+title: Commit Bit Assignment
+author: Brian Bouterse
+created: 01-06-2018
+status: Approved
+---
+
+## Summary
+
+For pulpcore and its related tools, there is no written process to describe giving the commit bit to
+a contributor for all or a portion of the codebase. The existing committers want to openly document
+the process.
+
+
+## Motivation
+
+Historically the commit bit was given on day 0 when hired on the core team at Red Hat.  In Oct 2017
+the existing committers decided to stop that practice and instead document an open process.
+Engineers hired on the Pulp team since Oct '17 have not received commit bit.
+
+We have not yet documented an open process of which to give a proven contributor commit access to
+all or a portion of the codebase.
+
+
+## Scope
+
+This formally applies to the following core repositories and core-team maintained plugins:
+
+Core Repos:
+* pulp/pulp
+* pulp/devel
+* pulp/pulp-ci
+
+Plugin Repos:
+* pulp/pulp_file
+* pulp/pulp_python
+* pulp/pulp_rpm
+* pulp/crane
+* pulp/pulp_docker
+* pulp/pulp_puppet
+* pulp/pulp_ostree
+
+This policy is intended as the default for all software in the Pulp ecosystem unless explicitly
+stated otherwise.
+
+
+## Criteria
+
+Overall the candidate must have demonstrated commitment and care towards the needs of all Pulp
+users and not only their own interests. Also they must have the experience to be trusted with major
+aspects of Pulp functionality in that area.
+
+These requirements are somewhat vague by design and leave the decision to the judgement of the
+existing developers. Users rely on the judgement of developers already, so to rely on that judgement
+to accept new contributors is reasonable. Anyone who specifically wants to get more involved should
+approach the core devs about mentorship.
+
+
+## Process
+
+A nomination or self-nomination can be sent to the pulp-dev email list and must contain state the
+following:
+
+* Name and email of the nominee. This can be a self-nomination.
+* Repositories being requested
+* [Specific paths](https://blog.github.com/2017-07-06-introducing-code-owners/) or the entire repo
+* Vote end date. Must be 7 calendar days from now.
+
+To pass, a unanimous +1 vote is required from other committers in that area. Specifically:
+
+* Adding a committer to a subsystem requires 100% vote participation from all existing maintainers
+  of that subsystem.
+* Creating a first owner of a subsystem requires 100% vote participation from that repository's
+  committers.
+* Adding a committer for a repository requires 100% vote participation from that repository's
+  committers. 
+
+If a nomination does not pass, the candidate may be re-nominated after a cool down period of 60
+days.
+
+
+## Drawbacks
+
+A single developer can block a new candidate. This could limit contribution unnecessarily and
+possibly create fairness issues.
+
+Candidates might get waived through because casting a blocking vote can be uncomfortable.
+
+
+## Alternatives
+
+One alternative is to never add new committers. That is not a good option.
+
+Another alternative is to use hard metrics such as time involved, feature planned and implemented,
+bugs fixed, etc. Overall hard metric system can be gamed which is a major downside. Also a metrics
+based process does not help unify the committer base like a unanimous vote would.
+
+
+## Unresolved Questions
+
+How will the commit bit be removed?


### PR DESCRIPTION
This pup establishes a process and criteria to give the commit bit to
contributors within the Pulp software ecosystem.