### PR TITLE
Rename CCRC to GPLCC

### DIFF
--- a/pup-0005.md
+++ b/pup-0005.md
@@ -1,13 +1,14 @@
 ---
-title: Common Cure Rights Commitment
+title: GPL Cooperation Commitment
 author: Richard Fontana
 created: 13-Apr-2018
 status: Approved
+version: 2
 ---
 
 ## Summary
 
-This proposal adopts the Common Cure Rights Commitment (CCRC) for the
+This proposal adopts the GPL Cooperation Commitment (GPLCC) for the
 Pulp project.
 
 ## Motivation
@@ -35,13 +36,13 @@ on to this
 
 In November 2017, a coalition of companies led by Red Hat
 [announced](https://www.redhat.com/en/about/press-releases/technology-industry-leaders-join-forces-increase-predictability-open-source-licensing)
-that they were adopting a similar commitment, the CCRC, for all of
+that they were adopting a similar commitment, the GPLCC, for all of
 their copyrighted code that was licensed under GPLv2, LGPLv2.0 and
 LGPLv2.1. Red Hat persuaded an additional set of companies to
 [adopt](https://www.redhat.com/en/about/press-releases/momentum-builds-new-wave-technology-industry-leaders-join-efforts-increase-predictability-open-source-licensing)
-the CCRC in March 2018.
+the GPLCC in March 2018.
 
-Red Hat would like to encourage projects to adopt the CCRC as
+Red Hat would like to encourage projects to adopt the GPLCC as
 well. The issue is relevant for projects maintained or led by Red Hat
 developers for a few reasons: (1) GPLv2 and LGPLv2.x are licenses that
 many Red Hat developers continue to prefer; (2) projects led by Red
@@ -50,16 +51,17 @@ opposed to an asymmetrical contributor license agreement); and (3)
 traditionally Red Hat developers have exercised broad discretion on
 project licensing policy.
 
-Pulp is a good candidate for adoption of the CCRC at the project
+Pulp is a good candidate for adoption of the GPLCC at the project
 level. Pulp is a GPLv2-licensed community project of commercial
 significance to Red Hat, and Pulp has been making significant efforts
 to build a community around the project, which over time will
 encourage contributions to the project from various copyright holders.
 
-## Common Cure Rights Commitment, version 1.0
+## GPL Cooperation Commitment, Version 1.0
 
-Common Cure Rights Commitment, version 1.0
- 
+GPL Cooperation Commitment
+Version 1.0
+
 Before filing or continuing to prosecute any legal proceeding or claim
 (other than a Defensive Action) arising from termination of a Covered
 License, we commit to extend to the person or entity ('you') accused
@@ -103,7 +105,7 @@ contributor.
 
 This work is available under a [Creative Commons Attribution-ShareAlike 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/).
 
-## Displaying the CCRC
+## Displaying the GPLCC
 
 A file named COMMITMENT will be added to the root of the Pulp git
 repository, in the same directory as the LICENSE file. Other Pulp
@@ -116,19 +118,19 @@ None.
 
 ## Alternatives
 
-### Continue use of GPLv2 without the CCRC
+### Continue use of GPLv2 without the GPLCC
 
 The Pulp project can continue to use GPLv2 without adding the
-CCRC. Addition of the CCRC provides a reduction in risk of unfair GPL
+GPLCC. Addition of the GPLCC provides a reduction in risk of unfair GPL
 enforcement against users of Pulp, but this was not a large risk to
-begin with. The major expected impact of adoption of the CCRC is its
+begin with. The major expected impact of adoption of the GPLCC is its
 influence on general norms around GPLv2 interpretation and enforcement
 in the larger open source community.
 
 ### Relicense Pulp to an open source license with a cure provision
 
 The Pulp project could relicense from GPLv2 to GPLv3, which would
-eliminate any point in adopting the CCRC since GPLv3 already has the
+eliminate any point in adopting the GPLCC since GPLv3 already has the
 cure and repose provisions. Such relicensing is probably possible
 though might take some time to effectuate, and may not be preferred by
 the Pulp developers or community.


### PR DESCRIPTION
The "Common Cure Rights Commitment" is being
renamed to "GPL Cooperation Commitment".
As part of our effort to promote this initiative
further we want to standardize on that name (GPLCC).

https://pulp.plan.io/issues/4153

re: #4153

Signed-off-by: Pavel Picka <ppicka@redhat.com>